### PR TITLE
fix entities loot table

### DIFF
--- a/data/minecraft/loot_table/entities/evoker.json
+++ b/data/minecraft/loot_table/entities/evoker.json
@@ -8,6 +8,15 @@
           "condition": "minecraft:killed_by_player"
         },
         {
+          "condition": "minecraft:entity_properties",
+          "entity": "direct_attacker",
+          "predicate": {
+            "type_specific": {
+              "type": "minecraft:player"
+            }
+          }
+        },
+        {
           "condition": "minecraft:random_chance_with_enchanted_bonus",
           "enchanted_chance": {
             "type": "minecraft:linear",
@@ -40,6 +49,9 @@
       "bonus_rolls": 0.0,
       "conditions": [
         {
+          "condition": "minecraft:killed_by_player"
+        },
+        {
           "condition": "minecraft:entity_properties",
           "entity": "this",
           "predicate": {
@@ -66,6 +78,15 @@
       "conditions": [
         {
           "condition": "minecraft:killed_by_player"
+        },
+        {
+          "condition": "minecraft:entity_properties",
+          "entity": "direct_attacker",
+          "predicate": {
+            "type_specific": {
+              "type": "minecraft:player"
+            }
+          }
         },
         {
           "condition": "minecraft:entity_properties",

--- a/data/minecraft/loot_table/entities/piglin.json
+++ b/data/minecraft/loot_table/entities/piglin.json
@@ -2,8 +2,54 @@
   "type": "minecraft:entity",
   "pools": [
     {
-      "rolls": 1,
-      "bonus_rolls": 0,
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:all_of",
+          "terms": [
+            {
+              "condition": "minecraft:killed_by_player"
+            },
+            {
+              "condition": "minecraft:entity_properties",
+              "entity": "direct_attacker",
+              "predicate": {
+                "type_specific": {
+                  "type": "minecraft:player"
+                }
+              }
+            },
+            {
+              "condition": "minecraft:location_check",
+              "predicate": {
+                "structures": "minecraft:bastion_remnant"
+              }
+            },
+            {
+              "condition": "minecraft:inverted",
+              "term": {
+                "condition": "minecraft:entity_properties",
+                "entity": "direct_attacker",
+                "predicate": {
+                  "effects": {
+                    "more_vault:bastion_omen": {}
+                  }
+                }
+              }
+            }
+          ]
+        },
+        {
+          "condition": "minecraft:random_chance_with_enchanted_bonus",
+          "enchanted_chance": {
+            "type": "minecraft:linear",
+            "base": 0.6,
+            "per_level_above_first": 0.1
+          },
+          "enchantment": "minecraft:looting",
+          "unenchanted_chance": 0.5
+        }
+      ],
       "entries": [
         {
           "type": "minecraft:item",
@@ -19,44 +65,7 @@
           ]
         }
       ],
-      "conditions": [
-        {
-          "condition": "minecraft:all_of",
-          "terms": [
-            {
-              "condition": "minecraft:killed_by_player"
-            },
-            {
-              "condition": "minecraft:location_check",
-              "predicate": {
-                "structures": "minecraft:bastion_remnant"
-              }
-            },
-            {
-              "condition": "minecraft:inverted",
-              "term": {
-                "condition": "minecraft:entity_properties",
-                "entity": "attacker",
-                "predicate": {
-                  "effects": {
-                    "more_vault:bastion_omen": {}
-                  }
-                }
-              }
-            }
-          ]
-        },
-        {
-          "condition": "minecraft:random_chance_with_enchanted_bonus",
-          "enchantment": "minecraft:looting",
-          "unenchanted_chance": 0.5,
-          "enchanted_chance": {
-            "type": "minecraft:linear",
-            "base": 0.6,
-            "per_level_above_first": 0.1
-          }
-        }
-      ]
+      "rolls": 1.0
     }
   ],
   "random_sequence": "minecraft:entities/piglin"

--- a/data/minecraft/loot_table/entities/piglin_brute.json
+++ b/data/minecraft/loot_table/entities/piglin_brute.json
@@ -11,10 +11,19 @@
               "condition": "minecraft:killed_by_player"
             },
             {
+              "condition": "minecraft:entity_properties",
+              "entity": "direct_attacker",
+              "predicate": {
+                "type_specific": {
+                  "type": "minecraft:player"
+                }
+              }
+            },
+            {
               "condition": "minecraft:inverted",
               "term": {
                 "condition": "minecraft:entity_properties",
-                "entity": "attacker",
+                "entity": "direct_attacker",
                 "predicate": {
                   "effects": {
                     "more_vault:bastion_omen": {}
@@ -63,7 +72,16 @@
             },
             {
               "condition": "minecraft:entity_properties",
-              "entity": "attacker",
+              "entity": "direct_attacker",
+              "predicate": {
+                "type_specific": {
+                  "type": "minecraft:player"
+                }
+              }
+            },
+            {
+              "condition": "minecraft:entity_properties",
+              "entity": "direct_attacker",
               "predicate": {
                 "effects": {
                   "more_vault:bastion_omen": {}

--- a/data/minecraft/loot_table/entities/shulker.json
+++ b/data/minecraft/loot_table/entities/shulker.json
@@ -33,10 +33,19 @@
               "condition": "minecraft:killed_by_player"
             },
             {
+              "condition": "minecraft:entity_properties",
+              "entity": "direct_attacker",
+              "predicate": {
+                "type_specific": {
+                  "type": "minecraft:player"
+                }
+              }
+            },
+            {
               "condition": "minecraft:inverted",
               "term": {
                 "condition": "minecraft:entity_properties",
-                "entity": "attacker",
+                "entity": "direct_attacker",
                 "predicate": {
                   "effects": {
                     "more_vault:city_omen": {}
@@ -85,7 +94,16 @@
             },
             {
               "condition": "minecraft:entity_properties",
-              "entity": "attacker",
+              "entity": "direct_attacker",
+              "predicate": {
+                "type_specific": {
+                  "type": "minecraft:player"
+                }
+              }
+            },
+            {
+              "condition": "minecraft:entity_properties",
+              "entity": "direct_attacker",
               "predicate": {
                 "effects": {
                   "more_vault:city_omen": {}

--- a/data/minecraft/loot_table/entities/vindicator.json
+++ b/data/minecraft/loot_table/entities/vindicator.json
@@ -44,6 +44,15 @@
         },
         {
           "condition": "minecraft:entity_properties",
+          "entity": "direct_attacker",
+          "predicate": {
+            "type_specific": {
+              "type": "minecraft:player"
+            }
+          }
+        },
+        {
+          "condition": "minecraft:entity_properties",
           "entity": "this",
           "predicate": {
             "type_specific": {

--- a/data/minecraft/loot_table/entities/warden.json
+++ b/data/minecraft/loot_table/entities/warden.json
@@ -16,6 +16,15 @@
       "conditions": [
         {
           "condition": "minecraft:killed_by_player"
+        },
+        {
+          "condition": "minecraft:entity_properties",
+          "entity": "direct_attacker",
+          "predicate": {
+            "type_specific": {
+              "type": "minecraft:player"
+            }
+          }
         }
       ],
       "entries": [


### PR DESCRIPTION
fix a problem where certain items could be looted by attacking the entity but leaving it to be killed by an entity other than a player