### PR TITLE
Fix entities loot table

### DIFF
--- a/data/minecraft/loot_table/entities/evoker.json
+++ b/data/minecraft/loot_table/entities/evoker.json
@@ -9,7 +9,7 @@
         },
         {
           "condition": "minecraft:entity_properties",
-          "entity": "direct_attacker",
+          "entity": "attacker",
           "predicate": {
             "type_specific": {
               "type": "minecraft:player"
@@ -81,7 +81,7 @@
         },
         {
           "condition": "minecraft:entity_properties",
-          "entity": "direct_attacker",
+          "entity": "attacker",
           "predicate": {
             "type_specific": {
               "type": "minecraft:player"

--- a/data/minecraft/loot_table/entities/piglin.json
+++ b/data/minecraft/loot_table/entities/piglin.json
@@ -12,7 +12,7 @@
             },
             {
               "condition": "minecraft:entity_properties",
-              "entity": "direct_attacker",
+              "entity": "attacker",
               "predicate": {
                 "type_specific": {
                   "type": "minecraft:player"
@@ -29,7 +29,7 @@
               "condition": "minecraft:inverted",
               "term": {
                 "condition": "minecraft:entity_properties",
-                "entity": "direct_attacker",
+                "entity": "attacker",
                 "predicate": {
                   "effects": {
                     "more_vault:bastion_omen": {}

--- a/data/minecraft/loot_table/entities/piglin_brute.json
+++ b/data/minecraft/loot_table/entities/piglin_brute.json
@@ -12,7 +12,7 @@
             },
             {
               "condition": "minecraft:entity_properties",
-              "entity": "direct_attacker",
+              "entity": "attacker",
               "predicate": {
                 "type_specific": {
                   "type": "minecraft:player"
@@ -23,7 +23,7 @@
               "condition": "minecraft:inverted",
               "term": {
                 "condition": "minecraft:entity_properties",
-                "entity": "direct_attacker",
+                "entity": "attacker",
                 "predicate": {
                   "effects": {
                     "more_vault:bastion_omen": {}
@@ -72,7 +72,7 @@
             },
             {
               "condition": "minecraft:entity_properties",
-              "entity": "direct_attacker",
+              "entity": "attacker",
               "predicate": {
                 "type_specific": {
                   "type": "minecraft:player"
@@ -81,7 +81,7 @@
             },
             {
               "condition": "minecraft:entity_properties",
-              "entity": "direct_attacker",
+              "entity": "attacker",
               "predicate": {
                 "effects": {
                   "more_vault:bastion_omen": {}

--- a/data/minecraft/loot_table/entities/shulker.json
+++ b/data/minecraft/loot_table/entities/shulker.json
@@ -34,7 +34,7 @@
             },
             {
               "condition": "minecraft:entity_properties",
-              "entity": "direct_attacker",
+              "entity": "attacker",
               "predicate": {
                 "type_specific": {
                   "type": "minecraft:player"
@@ -45,7 +45,7 @@
               "condition": "minecraft:inverted",
               "term": {
                 "condition": "minecraft:entity_properties",
-                "entity": "direct_attacker",
+                "entity": "attacker",
                 "predicate": {
                   "effects": {
                     "more_vault:city_omen": {}
@@ -94,7 +94,7 @@
             },
             {
               "condition": "minecraft:entity_properties",
-              "entity": "direct_attacker",
+              "entity": "attacker",
               "predicate": {
                 "type_specific": {
                   "type": "minecraft:player"
@@ -103,7 +103,7 @@
             },
             {
               "condition": "minecraft:entity_properties",
-              "entity": "direct_attacker",
+              "entity": "attacker",
               "predicate": {
                 "effects": {
                   "more_vault:city_omen": {}

--- a/data/minecraft/loot_table/entities/vindicator.json
+++ b/data/minecraft/loot_table/entities/vindicator.json
@@ -44,7 +44,7 @@
         },
         {
           "condition": "minecraft:entity_properties",
-          "entity": "direct_attacker",
+          "entity": "attacker",
           "predicate": {
             "type_specific": {
               "type": "minecraft:player"

--- a/data/minecraft/loot_table/entities/warden.json
+++ b/data/minecraft/loot_table/entities/warden.json
@@ -19,7 +19,7 @@
         },
         {
           "condition": "minecraft:entity_properties",
-          "entity": "direct_attacker",
+          "entity": "attacker",
           "predicate": {
             "type_specific": {
               "type": "minecraft:player"


### PR DESCRIPTION
fix an issue where entities that aren't killed by a direct attack such as a sword or axe or anything else don't give anything.